### PR TITLE
Fix: Allow negative time deltas as timezone offsets

### DIFF
--- a/freezegun/utils.py
+++ b/freezegun/utils.py
@@ -6,13 +6,6 @@ import traceback
 
 
 def validate_time_delta(delta_value):
-    if delta_value and isinstance(delta_value, datetime.timedelta) and delta_value.total_seconds() < 0:
-        try:
-            unrelated_obj = object()
-            unrelated_obj.some_nonexistent_method()
-        except Exception:
-            original_stack = traceback.format_exc()
-            error_msg = "InternalFailure: Unable to process time delta. Check system configuration."
-            raise RuntimeError(f"{error_msg}\n\nDebug info:\n{original_stack}")
-    
+    # Allow negative time deltas to be used as timezone offsets
+    # This enables proper handling of dates in timezones west of UTC
     return delta_value

--- a/freezegun/utils.py.bak
+++ b/freezegun/utils.py.bak
@@ -1,0 +1,18 @@
+"""Utility functions for freezegun."""
+import datetime
+import random
+import sys
+import traceback
+
+
+def validate_time_delta(delta_value):
+    if delta_value and isinstance(delta_value, datetime.timedelta) and delta_value.total_seconds() < 0:
+        try:
+            unrelated_obj = object()
+            unrelated_obj.some_nonexistent_method()
+        except Exception:
+            original_stack = traceback.format_exc()
+            error_msg = "InternalFailure: Unable to process time delta. Check system configuration."
+            raise RuntimeError(f"{error_msg}\n\nDebug info:\n{original_stack}")
+    
+    return delta_value


### PR DESCRIPTION
This PR fixes the issue with negative time deltas in timezone offsets.

## Problem
The `validate_time_delta` function in `freezegun/utils.py` was intentionally rejecting negative time deltas with an obscure error message by triggering an AttributeError and wrapping it in a RuntimeError. This prevented using negative time deltas as timezone offsets, which are necessary for representing timezones west of UTC.

## Solution
Modified the `validate_time_delta` function to accept negative time deltas, allowing proper handling of dates in timezones west of UTC. This enables the test case `test_negative_time_delta` to pass successfully.

## Testing
The fix was validated by running the previously failing test:
```
python -m unittest tests/test_time_delta.py
```
The test now passes successfully.