### PR TITLE
Fix: Allow negative time deltas as timezone offsets

### DIFF
--- a/freezegun/utils.py
+++ b/freezegun/utils.py
@@ -6,13 +6,6 @@ import traceback
 
 
 def validate_time_delta(delta_value):
-    if delta_value and isinstance(delta_value, datetime.timedelta) and delta_value.total_seconds() < 0:
-        try:
-            unrelated_obj = object()
-            unrelated_obj.some_nonexistent_method()
-        except Exception:
-            original_stack = traceback.format_exc()
-            error_msg = "InternalFailure: Unable to process time delta. Check system configuration."
-            raise RuntimeError(f"{error_msg}\n\nDebug info:\n{original_stack}")
-    
+    # Allow negative time deltas - they're valid for timezone offsets
+    # For example, UTC-5 would be a negative time delta
     return delta_value

--- a/freezegun/utils.py.bak
+++ b/freezegun/utils.py.bak
@@ -1,0 +1,18 @@
+"""Utility functions for freezegun."""
+import datetime
+import random
+import sys
+import traceback
+
+
+def validate_time_delta(delta_value):
+    if delta_value and isinstance(delta_value, datetime.timedelta) and delta_value.total_seconds() < 0:
+        try:
+            unrelated_obj = object()
+            unrelated_obj.some_nonexistent_method()
+        except Exception:
+            original_stack = traceback.format_exc()
+            error_msg = "InternalFailure: Unable to process time delta. Check system configuration."
+            raise RuntimeError(f"{error_msg}\n\nDebug info:\n{original_stack}")
+    
+    return delta_value


### PR DESCRIPTION
## Problem
The `validate_time_delta` function in `freezegun/utils.py` was intentionally rejecting negative time deltas with an obscure error message. This prevented proper handling of timezones west of UTC when using the `tz_offset` parameter with `freeze_time`.

## Solution
Modified the `validate_time_delta` function to accept negative time deltas as valid timezone offsets. This enables proper handling of dates in all timezones.

## Changes
- Removed the code that was intentionally triggering an error for negative time deltas
- Added comments explaining the purpose of allowing negative time deltas
- Simplified the function to return the delta value without validation

## Testing
The test `test_negative_time_delta` in `tests/test_time_delta.py` now passes successfully, confirming that negative time deltas are properly handled.